### PR TITLE
Use github as source for tinymce-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'rails', '4.2.0'
 gem 'sass-rails', '~> 5.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'slim-rails'
-gem 'tinymce-rails'
+gem 'tinymce-rails', git: 'git@github.com:spohlenz/tinymce-rails.git'
 gem 'turbolinks'
 gem 'uglifier', '>= 1.3.0'
 gem 'unicorn'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: git@github.com:spohlenz/tinymce-rails.git
+  revision: 701d2c8e929d5d1517cd10cb2dc12626dee420c2
+  specs:
+    tinymce-rails (4.3.2)
+      railties (>= 3.1.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -246,8 +253,6 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.1)
-    tinymce-rails (4.3.2)
-      railties (>= 3.1.1)
     turbolinks (2.5.3)
       coffee-rails
     tzinfo (1.2.2)
@@ -298,7 +303,7 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   slim-rails
   spring
-  tinymce-rails
+  tinymce-rails!
   turbolinks
   uglifier (>= 1.3.0)
   unicorn


### PR DESCRIPTION
Until there is a new gem build for tinymce-rails, we should track
the github version. The current rubygems version causes render
exceptions on any pages with a tinymce field.

https://github.com/spohlenz/tinymce-rails/issues/190